### PR TITLE
Updated Prototype css selector to generate security codes in Firefox 36....

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,8 @@
 {
-    "name":"aedmonds/magento-two-factor-authentication",
+    "name":"magento-hackathon/magento-two-factor-authentication",
     "type":"magento-module",
-    "homepage":"https://github.com/aligent/Magento-Two-factor-Authentication",
+    "license": "MIT",
+    "homepage":"https://github.com/magento-hackathon/Magento-Two-factor-Authentication",
     "description":"Implementation of an two-factor-authentication using Google's 2-Step Verification algorithm",
     "require":{
         "magento-hackathon/magento-composer-installer":"*"

--- a/src/app/design/adminhtml/default/default/template/twofactor/questions.phtml
+++ b/src/app/design/adminhtml/default/default/template/twofactor/questions.phtml
@@ -48,8 +48,8 @@
         for (var i = 0; i < 10; i++) {
             code += possible.charAt(Math.floor(Math.random() * possible.length));
         }
-        var question = $$('[name="questions['+iterator+'][question]"')[0];
-        var answer = $$('[name="questions['+iterator+'][answer]"')[0];
+        var question = $$('[name="questions['+iterator+'][question]"]')[0];
+        var answer = $$('[name="questions['+iterator+'][answer]"]')[0];
         if (question && answer) {
             question.value = 'Secret Code #'+(iterator+1);
             answer.type = 'text';


### PR DESCRIPTION
Solves #9: "Generate" Button does not work in Firefox 36.0