### PR TITLE
Make the cookie work with customers:

### DIFF
--- a/src/app/code/community/MageHackDay/TwoFactorAuth/Model/Resource/User/Cookie.php
+++ b/src/app/code/community/MageHackDay/TwoFactorAuth/Model/Resource/User/Cookie.php
@@ -2,25 +2,50 @@
 
 class MageHackDay_TwoFactorAuth_Model_Resource_User_Cookie extends Mage_Core_Model_Resource_Db_Abstract
 {
+    const COOKIE_ENTITY_ADMIN = 'admin';
+    const COOKIE_ENTITY_CUSTOMER = 'customer';
+    protected $fieldMap = null;
+
     protected function _construct()
     {
         $this->_init('twofactorauth/user_cookie', 'cookie_id');
+        $this->fieldMap = array(
+            self::COOKIE_ENTITY_ADMIN => 'user_id',
+            self::COOKIE_ENTITY_CUSTOMER => 'customer_id',
+        );
     }
 
+    private function _getUserId($userId, $entity)
+    {
+        if ($entity == self::COOKIE_ENTITY_ADMIN && $userId instanceof Mage_Admin_Model_User) {
+            $userId = $userId->getId();
+        } elseif ($entity == self::COOKIE_ENTITY_CUSTOMER && $userId instanceof Mage_Customer_Model_Customer) {
+            $userId = $userId->getId();
+        }
+        if (!is_int($userId) || intval($userId) <= 0) {
+            if(extension_loaded('newrelic')) {
+                $msg = 'Invalid ID supplied. Trace follows' . PHP_EOL . PHP_EOL;
+                $msg .= debug_backtrace();
+                newrelic_notice_error(null, $msg);
+            }
+            Mage::throwException('Supplied user ID does not resolve to a positive integer');
+        }
+        return $userId;
+    }
     /**
      * Check whether the user has cookies
      *
-     * @param int|Mage_Admin_Model_User $userId
+     * @param int|Mage_Admin_Model_User|Mage_Customer_Model_Customer $userId
+     * @param string $entity
      * @return bool
      */
-    public function hasCookies($userId)
+    public function hasCookies($userId, $entity=self::COOKIE_ENTITY_ADMIN)
     {
-        if ($userId instanceof Mage_Admin_Model_User) {
-            $userId = $userId->getId();
-        }
+        $userId = $this->_getUserId($userId, $entity);
+        $field = $this->fieldMap[$entity];
         $select = $this->getReadConnection()->select()
             ->from($this->getMainTable(), array('count' => new Zend_Db_Expr('COUNT(*)')))
-            ->where('user_id = ?', $userId);
+            ->where("$field = ?", $userId); // No injection here, hardcoded local variable
         return (bool) $this->getReadConnection()->fetchOne($select);
     }
 
@@ -28,16 +53,16 @@ class MageHackDay_TwoFactorAuth_Model_Resource_User_Cookie extends Mage_Core_Mod
      * Retrieve cookies for the user
      *
      * @param int|Mage_Admin_Model_User $userId
+     * @param string $entity
      * @return array
      */
-    public function getCookies($userId)
+    public function getCookies($userId, $entity=self::COOKIE_ENTITY_ADMIN)
     {
-        if ($userId instanceof Mage_Admin_Model_User) {
-            $userId = $userId->getId();
-        }
+        $userId = $this->_getUserId($userId, $entity);
+        $field = $this->fieldMap[$entity];
         $select = $this->getReadConnection()->select()
             ->from($this->getMainTable(), 'cookie')
-            ->where('user_id = ?', $userId);
+            ->where("$field = ?", $userId);
         return (array) $this->getReadConnection()->fetchCol($select);
     }
 
@@ -46,15 +71,15 @@ class MageHackDay_TwoFactorAuth_Model_Resource_User_Cookie extends Mage_Core_Mod
      *
      * @param int|Mage_Admin_Model_User $userId
      * @param string $cookie
+     * @param string $entity
      * @return MageHackDay_TwoFactorAuth_Model_Resource_User_Cookie
      */
-    public function saveCookie($userId, $cookie)
+    public function saveCookie($userId, $cookie, $entity=self::COOKIE_ENTITY_ADMIN)
     {
-        if ($userId instanceof Mage_Admin_Model_User) {
-            $userId = $userId->getId();
-        }
+        $userId = $this->_getUserId($userId, $entity);
+        $field = $this->fieldMap[$entity];
         $data = array(
-            'user_id' => (int)$userId,
+            $field => (int)$userId,
             'cookie'  => (string)$cookie,
         );
         $this->_getWriteAdapter()->insertOnDuplicate($this->getMainTable(), $data);
@@ -65,14 +90,14 @@ class MageHackDay_TwoFactorAuth_Model_Resource_User_Cookie extends Mage_Core_Mod
      * Delete cookies for the user
      *
      * @param int|Mage_Admin_Model_User $userId
+     * @param string $entity
      * @return MageHackDay_TwoFactorAuth_Model_Resource_User_Cookie
      */
-    public function deleteCookies($userId)
+    public function deleteCookies($userId, $entity=self::COOKIE_ENTITY_ADMIN)
     {
-        if ($userId instanceof Mage_Admin_Model_User) {
-            $userId = $userId->getId();
-        }
-        $where = $this->_getWriteAdapter()->quoteInto('user_id = ?', $userId);
+        $userId = $this->_getUserId($userId, $entity);
+        $field = $this->fieldMap[$entity];
+        $where = $this->_getWriteAdapter()->quoteInto("$field = ?", $userId);
         $this->_getWriteAdapter()->delete($this->getMainTable(), $where);
         return $this;
     }

--- a/src/app/code/community/MageHackDay/TwoFactorAuth/sql/twofactorauth_setup/upgrade-0.1.3-0.1.4.php
+++ b/src/app/code/community/MageHackDay/TwoFactorAuth/sql/twofactorauth_setup/upgrade-0.1.3-0.1.4.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Always nice to give cookies to customers.
+ *
+ * Changes:
+ * - Add column to hold customer information
+ * - Make user_id field nullable now that we support more entities.
+ * - Add foreign key to customer_entity.
+ * - Add unique key for cookie/customer_id combination
+ * - Increase storage for cookie. Time teaches us hashes become obsolete.
+ */
+/** @var Mage_Core_Model_Resource_Setup $installer */
+$installer = $this;
+$installer->startSetup();
+
+$tbl = $installer->getTable('twofactorauth/user_cookie');
+$installer->getConnection()->addColumn(
+    $tbl,
+    'customer_id',
+    array(
+        'type'      => Varien_Db_Ddl_Table::TYPE_INTEGER,
+        'length'    => null,
+        'unsigned'  => true,
+        'nullable'  => true,
+        'comment'   => 'Link to customer for frontend authentication'
+    )
+);
+$installer->getConnection()->addIndex(
+    $tbl,
+    'UNQ_CUSTOMER_ID_COOKIE_USER_ID_COOKIE', // Err...I think I'm respecting the naming convention...
+    array('customer_id', 'cookie'),
+    Varien_Db_Adapter_Interface::INDEX_TYPE_UNIQUE
+);
+$installer->getConnection()->modifyColumn(
+    $tbl,
+    'user_id',
+    array(
+        'type'      => Varien_Db_Ddl_Table::TYPE_INTEGER,
+        'length'    => null,
+        'unsigned'  => true,
+        'nullable'  => true,
+        'comment'   => 'Admin User ID'
+    )
+);
+$installer->getConnection()->modifyColumn(
+    $tbl,
+    'cookie',
+    array(
+        'type'      => Varien_Db_Ddl_Table::TYPE_VARCHAR,
+        'length'    => 128, // will work up to sha512
+        'nullable'  => false, // Not sure why this was set to true, shouldn't be.
+        'comment'   => 'Cookie value'
+    )
+);
+$installer->getConnection()->addForeignKey(
+    'FK_CUSTOMER_ID_CUSTOMER_ENTITY_ENTITY_ID',
+    $tbl,
+    'customer_id',
+    $installer->getConnection()->getTableName('customer/customer'),
+    'entity_id',
+    Varien_Db_Adapter_Interface::FK_ACTION_CASCADE,
+    Varien_Db_Adapter_Interface::FK_ACTION_CASCADE
+);
+$installer->endSetup();
+


### PR DESCRIPTION
- Currently the cookie is tied to the admin user. Hook in with
  customer_entity for frontend.
- Make foreign key to admin user nullable, now that we support another
  entity.
- To support multiple entities, let consumer select it through an extra
  argument on relevant methods.

While in here:
- Storage for the cookie value is tight: hashes go obsolete. Be
  prepared.

TODO:
- Consumers of refactored methods, specifically for customer
- generateCookie is really a resource method?
- reach concensus about expiration time.
- do we need to ensure no hash collisions exist or is the chance for
  abuse sufficiently low?
- Add a cookie collection and store browser/device to allow presenting
  and deleting cookies for lost/stolen/etc. machines.