### PR TITLE
Fix missing admin secret key in reset link

### DIFF
--- a/src/app/design/adminhtml/default/default/template/twofactor/qr.phtml
+++ b/src/app/design/adminhtml/default/default/template/twofactor/qr.phtml
@@ -63,7 +63,7 @@
             </fieldset>
 
             <?php if ($this->getUser()->getTwofactorToken()): // Display reset link ?>
-                <a href="<?php echo $this->getUrl('adminhtml/twofactorauth/reset') ?>"
+                <a href="<?php echo Mage::helper("adminhtml")->getUrl('adminhtml/twofactorauth/reset') ?>"
                    title="<?php echo Mage::helper('twofactorauth')->__('Reset Two-Factor Authentication') ?>">
                     <?php echo Mage::helper('twofactorauth')->__('Reset Two-Factor Authentication') ?>
                 </a>

--- a/src/app/design/adminhtml/default/default/template/twofactor/resetbutton_user_edit.phtml
+++ b/src/app/design/adminhtml/default/default/template/twofactor/resetbutton_user_edit.phtml
@@ -3,7 +3,7 @@
 <button id="reset_on_useredit" title="<?php echo $this->__('Reset Two-Factor Authentication'); ?>" type="button"
   class="scalable delete"
   onclick="deleteConfirm('Are you sure you want to do this?', '<?php
-    echo $this->getUrl('adminhtml/twofactorauth/resetUser', ['user_id' => $user->getId()]); ?>')"
+    echo Mage::helper("adminhtml")->getUrl('adminhtml/twofactorauth/resetUser', ['user_id' => $user->getId()]); ?>')"
   ><span><?php echo $this->__('Reset Two-Factor Authentication'); ?></span></button>
 <script type="text/javascript">
     document.observe('dom:loaded', function(){


### PR DESCRIPTION
The link to reset 2FA on the account edit page was missing the secret key. Switching to the admin helper fixes this issue.

To replicate: With `admin/security/use_form_key` enabled, attempt to reset another admins 2FA from the user permissions area.